### PR TITLE
feat(liftover): Hermes UI for auto-liftover (genome_build, status, summary, admin)

### DIFF
--- a/pages/hermes/admin/liftover.vue
+++ b/pages/hermes/admin/liftover.vue
@@ -1,0 +1,82 @@
+<script setup>
+import { useDatasetStore } from '~/stores/DatasetStore';
+import { useUserStore } from '~/stores/UserStore';
+import { useToast } from 'primevue/usetoast';
+
+const store = useDatasetStore();
+const userStore = useUserStore();
+const toast = useToast();
+
+const currentBuild = ref(null);
+const selectedBuild = ref(null);
+const saving = ref(false);
+
+const buildOptions = [
+  { name: 'GRCh37 / hg19', value: 'hg19' },
+  { name: 'GRCh38 / hg38', value: 'grch38' },
+];
+
+const isAdmin = computed(() => userStore.user?.roles?.includes('admin'));
+
+onMounted(async () => {
+  if (!isAdmin.value) {
+    return navigateTo('/hermes');
+  }
+  const config = await store.getPortalConfig();
+  currentBuild.value = config?.target_genome_build ?? null;
+  selectedBuild.value = currentBuild.value;
+});
+
+async function saveBuild() {
+  if (!selectedBuild.value) return;
+  saving.value = true;
+  try {
+    const result = await store.updatePortalConfig(selectedBuild.value);
+    currentBuild.value = result.target_genome_build;
+    toast.add({ severity: 'success', summary: 'Saved', detail: 'Portal target build updated.', life: 3000 });
+  } catch (e) {
+    toast.add({ severity: 'error', summary: 'Error', detail: 'Failed to update portal target build.', life: 5000 });
+  } finally {
+    saving.value = false;
+  }
+}
+</script>
+
+<template>
+  <div class="grid">
+    <div class="col-6 col-offset-3">
+      <Card>
+        <template #title>Portal Liftover Configuration</template>
+        <template #content>
+          <div v-if="!isAdmin" class="text-center text-danger">Access denied.</div>
+          <div v-else class="flex flex-column gap-3">
+            <div>
+              <strong>Current target genome build:</strong>
+              {{ currentBuild ? buildOptions.find(o => o.value === currentBuild)?.name ?? currentBuild : 'Not set' }}
+            </div>
+            <div class="field">
+              <label for="targetBuild">Set target genome build</label>
+              <Dropdown
+                id="targetBuild"
+                v-model="selectedBuild"
+                :options="buildOptions"
+                optionLabel="name"
+                optionValue="value"
+                placeholder="Select target build"
+                class="w-full mt-1"
+              />
+            </div>
+            <Button
+              label="Save"
+              icon="bi-save"
+              :loading="saving"
+              :disabled="!selectedBuild || selectedBuild === currentBuild"
+              @click="saveBuild"
+            />
+          </div>
+        </template>
+      </Card>
+    </div>
+  </div>
+  <Toast position="top-center" />
+</template>

--- a/pages/hermes/admin/liftover.vue
+++ b/pages/hermes/admin/liftover.vue
@@ -43,13 +43,12 @@ async function saveBuild() {
 </script>
 
 <template>
-  <div class="grid">
+  <div v-if="isAdmin" class="grid">
     <div class="col-6 col-offset-3">
       <Card>
         <template #title>Portal Liftover Configuration</template>
         <template #content>
-          <div v-if="!isAdmin" class="text-center text-danger">Access denied.</div>
-          <div v-else class="flex flex-column gap-3">
+          <div class="flex flex-column gap-3">
             <div>
               <strong>Current target genome build:</strong>
               {{ currentBuild ? buildOptions.find(o => o.value === currentBuild)?.name ?? currentBuild : 'Not set' }}

--- a/pages/hermes/index.vue
+++ b/pages/hermes/index.vue
@@ -76,6 +76,12 @@ const getSeverity = (status) => {
             return "secondary";
         case "REVIEW REJECTED":
             return "warning";
+        case "SUBMITTED TO LIFTOVER":
+            return "warning";
+        case "LIFTOVER COMPLETE":
+            return "info";
+        case "LIFTOVER FAILED":
+            return "danger";
         default:
             return "info";
     }
@@ -93,6 +99,12 @@ const getIcon = (status) => {
             return "bi-x-square";
         case "REVIEW APPROVED":
             return "bi-check-square";
+        case "SUBMITTED TO LIFTOVER":
+            return "bi-arrow-left-right";
+        case "LIFTOVER COMPLETE":
+            return "bi-check-circle";
+        case "LIFTOVER FAILED":
+            return "bi-exclamation-triangle";
     }
 };
 
@@ -156,6 +168,11 @@ const columns = ref([
     field: "uploaded_by",
     filterType: "text",
     placeholder: "Search uploader",
+    sortable: true
+  },
+  {
+    header: "Build",
+    field: "genome_build",
     sortable: true
   },
   {

--- a/pages/hermes/new.vue
+++ b/pages/hermes/new.vue
@@ -72,6 +72,7 @@ const formSchema = yup.object({
         then: (schema) => schema.required('You must specifiy standard deviation age (controls) when you specify cases'),
         otherwise: (schema) => schema,
       }),
+  genomeBuild: yup.string().label('Genome Build').required().oneOf(['hg19', 'grch38', 'n/a']),
   referenceGenome: yup.string().label('Reference Genome').required(),
   genotypingArray: yup.string().label('Genotyping Array').required(),
   callingAlgorithm: yup.string().label('Calling Algorithm').required(),
@@ -127,6 +128,7 @@ const [maleProportionControls] = defineField('maleProportionControls');
 const [meanAgeCohort] = defineField('meanAgeCohort');
 const [sdAgeCohort] = defineField('sdAgeCohort');
 const [sdAgeControls] = defineField('sdAgeControls');
+const [genomeBuild] = defineField('genomeBuild');
 const [referenceGenome] = defineField('referenceGenome');
 const [genotypingArray] = defineField('genotypingArray');
 const [callingAlgorithm] = defineField('callingAlgorithm');
@@ -197,6 +199,14 @@ const genomeBuildOptions = ref([
     { name: "GRCh37/b37", value: "GRCh37/b37" },
 ]);
 
+const genomeBuildUploadOptions = ref([
+    { name: "GRCh37 / hg19", value: "hg19" },
+    { name: "GRCh38 / hg38", value: "grch38" },
+    { name: "N/A", value: "n/a" },
+]);
+
+const portalConfig = ref(null);
+
 const colOptions = ref([]);
 const requiredFields = ref([]);
 const selectedFields = ref({});
@@ -249,6 +259,7 @@ async function loadExistingData() {
     sdAgeControls.value = metadata.sdAgeControls;
     sdAgeRecruitment.value = metadata.sdAgeRecruitment;
 
+    genomeBuild.value = metadata.genomeBuild;
     referenceGenome.value = metadata.referenceGenome;
     genotypingArray.value = metadata.genotypingArray;
     callingAlgorithm.value = metadata.callingAlgorithm;
@@ -289,6 +300,7 @@ onMounted(async () => {
         limit: 1,
     };
     previousMetadata.value = await store.fetchHermesMetadata();
+    portalConfig.value = await store.getPortalConfig().catch(() => null);
     await loadExistingData();
     let fileInfos = await store.fetchFileUploads(paramsToString(params));
     if (fileInfos.length > 0) {
@@ -384,8 +396,25 @@ const requiredEffectFields = computed(() => {
   return betaAndSe || oddsRatioFields;
 });
 
+const genomeBuildLabel = (build) => {
+    const opt = genomeBuildUploadOptions.value.find(o => o.value === build);
+    return opt ? opt.name : build;
+};
+
+const liftoverNotice = computed(() => {
+    if (!portalConfig.value || !portalConfig.value.target_genome_build) return null;
+    if (!genomeBuild.value || genomeBuild.value === 'n/a') return null;
+    if (genomeBuild.value !== portalConfig.value.target_genome_build) {
+        return {
+            source: genomeBuildLabel(genomeBuild.value),
+            target: genomeBuildLabel(portalConfig.value.target_genome_build),
+        };
+    }
+    return null;
+});
+
 const step1Complete = computed(() => {
-    return Boolean(dataSetName.value);
+    return Boolean(dataSetName.value) && Boolean(genomeBuild.value);
 });
 const step2Complete = computed(() => {
     return Boolean(fileInfo.value.columns);
@@ -509,7 +538,8 @@ async function uploadSubmit(){
           fileName,
           dataSetName.value,
           metadata,
-          { 'fd': .2 }
+          { 'fd': .2 },
+          genomeBuild.value
       )
       if (validationRes.errors) {
         toast.add({
@@ -731,6 +761,26 @@ async function uploadSubmit(){
                 </Fieldset>
 
               <Fieldset legend="Genotyping Information">
+                <div class="field">
+                  <label for="genomeBuild">Genome Build</label>
+                  <Dropdown
+                      id="genomeBuild"
+                      v-model="genomeBuild"
+                      :options="genomeBuildUploadOptions"
+                      optionLabel="name"
+                      optionValue="value"
+                      placeholder="Select Genome Build"
+                      data-cy="genomeBuild"
+                      aria-describedby="genomeBuild-help"
+                      :class="{ 'p-invalid': errors.genomeBuild }"
+                  />
+                  <small id="genomeBuild-help" class="p-error">
+                    {{ errors.genomeBuild }}
+                  </small>
+                  <Message v-if="liftoverNotice" severity="info" :closable="false" class="mt-2">
+                    This file will be lifted from {{ liftoverNotice.source }} &rarr; {{ liftoverNotice.target }} before QC runs.
+                  </Message>
+                </div>
                 <div class="field">
                   <label for="reference">Reference Genome</label>
                   <Dropdown

--- a/pages/hermes/qc/[id].vue
+++ b/pages/hermes/qc/[id].vue
@@ -168,7 +168,7 @@ async function reviewDataset(id, value) {
             </div>
           </div>
           <details class="mb-3">
-            <summary class="cursor-pointer mb-2" style="cursor: pointer;">Per-Chromosome Breakdown</summary>
+            <summary class="cursor-pointer mb-2">Per-Chromosome Breakdown</summary>
             <DataTable :value="perChromosomeRows" size="small" class="mt-2">
               <Column field="chromosome" header="Chromosome" sortable />
               <Column field="input" header="Input" sortable />

--- a/pages/hermes/qc/[id].vue
+++ b/pages/hermes/qc/[id].vue
@@ -1,6 +1,8 @@
 <script setup>
 import { useDatasetStore } from '~/stores/DatasetStore';
 import { useToast } from 'primevue/usetoast';
+import Tag from 'primevue/tag';
+import Button from 'primevue/button';
 
 
 const route = useRoute();
@@ -12,6 +14,8 @@ const toast = useToast();
 const showReview = ref(true);
 const indels = ref(null);
 const adjustment = ref(null);
+const liftoverJob = ref(null);
+const perChromosomeRows = ref([]);
 import { useForm } from 'vee-validate';
 import * as yup from 'yup';
 
@@ -48,6 +52,17 @@ onMounted(async () => {
   frequencyDifferential.value = scriptOptions.fd;
   if (scriptOptions.it) {
     infoThreshold.value = scriptOptions.it;
+  }
+
+  liftoverJob.value = await store.getLiftoverSummary(id);
+  if (liftoverJob.value && liftoverJob.value.summary && liftoverJob.value.summary.per_chromosome) {
+    perChromosomeRows.value = Object.entries(liftoverJob.value.summary.per_chromosome).map(([chr, stats]) => ({
+      chromosome: chr,
+      input: stats.input,
+      lifted: stats.lifted,
+      unmapped: stats.unmapped,
+      strand_flips: stats.strand_flips,
+    }));
   }
 });
 
@@ -91,6 +106,11 @@ async function rerunQC() {
 
 }
 
+async function downloadUnmapped() {
+  const url = await store.getUnmappedDownloadUrl(id);
+  window.open(url, '_blank');
+}
+
 async function reviewDataset(id, value) {
   await store.reviewDataset(id, value);
   toast.add({
@@ -117,6 +137,58 @@ async function reviewDataset(id, value) {
       @click="openDownloadLink"
   />
   </div>
+  <div class="grid" v-if="liftoverJob">
+    <div class="col col-md-12 mb-4">
+      <Card>
+        <template #title>
+          <span class="mr-2">Liftover Summary: {{ liftoverJob.source_genome_build }} &rarr; {{ liftoverJob.target_genome_build }}</span>
+          <Tag :value="liftoverJob.status" :severity="liftoverJob.status === 'COMPLETE' ? 'success' : liftoverJob.status === 'FAILED' ? 'danger' : 'warning'" />
+        </template>
+        <template #content>
+          <div class="flex gap-4 mb-3">
+            <div>
+              <strong>Total Input:</strong> {{ liftoverJob.summary?.total_input_variants?.toLocaleString() }}
+            </div>
+            <div>
+              <strong>Lifted:</strong> {{ liftoverJob.summary?.total_lifted?.toLocaleString() }}
+            </div>
+            <div>
+              <strong>Unmapped:</strong> {{ liftoverJob.summary?.total_unmapped?.toLocaleString() }} ({{ liftoverJob.summary?.unmapped_pct?.toFixed(2) }}%)
+            </div>
+            <div>
+              <strong>Strand Flips:</strong> {{ liftoverJob.summary?.strand_flips?.toLocaleString() }}
+            </div>
+          </div>
+          <div class="flex gap-4 mb-3">
+            <div>
+              <strong>Chain File:</strong> {{ liftoverJob.summary?.chain_file }}
+            </div>
+            <div>
+              <strong>Duration:</strong> {{ liftoverJob.summary?.duration_seconds }}s
+            </div>
+          </div>
+          <details class="mb-3">
+            <summary class="cursor-pointer mb-2" style="cursor: pointer;">Per-Chromosome Breakdown</summary>
+            <DataTable :value="perChromosomeRows" size="small" class="mt-2">
+              <Column field="chromosome" header="Chromosome" sortable />
+              <Column field="input" header="Input" sortable />
+              <Column field="lifted" header="Lifted" sortable />
+              <Column field="unmapped" header="Unmapped" sortable />
+              <Column field="strand_flips" header="Strand Flips" sortable />
+            </DataTable>
+          </details>
+          <Button
+              label="Download Unmapped Variants"
+              icon="bi-download"
+              outlined
+              :disabled="!liftoverJob.summary?.total_unmapped"
+              @click="downloadUnmapped"
+          />
+        </template>
+      </Card>
+    </div>
+  </div>
+
   <div class="grid" v-can="'approveUpload'">
     <div class="col col-md-12 mb-4">
       <Card>

--- a/stores/DatasetStore.js
+++ b/stores/DatasetStore.js
@@ -390,10 +390,10 @@ export const useDatasetStore = defineStore("DatasetStore", {
             });
             return data;
         },
-        async validateHermesUpload(fileName, dataset, metadata, qc_script_options) {
+        async validateHermesUpload(fileName, dataset, metadata, qc_script_options, genome_build) {
             const { data } = await configuredAxios.post(
                 "/api/validate-hermes",
-              JSON.stringify({'file_name': fileName, dataset, metadata, qc_script_options})
+              JSON.stringify({'file_name': fileName, dataset, metadata, qc_script_options, ...(genome_build && { genome_build })})
             );
             return data;
         },
@@ -1092,6 +1092,28 @@ export const useDatasetStore = defineStore("DatasetStore", {
 
         async getHCMGWASValidationProgress(fileId) {
             const { data } = await hcmAxios.get(`/api/hcm/gwas-validate/${fileId}/progress`);
+            return data;
+        },
+
+        async getLiftoverSummary(fileId) {
+            try {
+                const { data } = await configuredAxios.get(`/api/hermes/liftover/${fileId}`);
+                return data;
+            } catch (err) {
+                if (err.response && err.response.status === 404) return null;
+                throw err;
+            }
+        },
+        async getUnmappedDownloadUrl(fileId) {
+            const { data } = await configuredAxios.get(`/api/hermes/liftover/${fileId}/unmapped-url`);
+            return data;
+        },
+        async getPortalConfig() {
+            const { data } = await configuredAxios.get('/api/hermes/portal-config');
+            return data;
+        },
+        async updatePortalConfig(targetGenomeBuild) {
+            const { data } = await configuredAxios.put('/api/hermes/portal-config', { target_genome_build: targetGenomeBuild });
             return data;
         },
 


### PR DESCRIPTION
## Summary

Frontend integration for the GWAS liftover feature. Wires the Hermes UI to the new endpoints landing in `data-registry-api` PR #64.

When a user uploads a Hermes GWAS file with a `genome_build` that differs from the portal's configured target, the backend automatically lifts the file before QC runs. This PR exposes that to the user.

## What's in the diff

- **`pages/hermes/new.vue`** — Required "Genome build" `<Dropdown>` on step 1 (`hg19`, `grch38`, with `n/a` as an explicit "I don't know" option). Step 1 won't advance until selected. After selection, an inline `<Message severity="info">` shows when the user-selected build differs from the portal target ("This file will be lifted from GRCh38 → hg19 before QC runs"). The new `genome_build` field is included in the `validate-hermes` request payload.
- **`pages/hermes/index.vue`** — New "Build" column. Three new `qc_status` `<Tag>` values: `SUBMITTED TO LIFTOVER` (warning), `LIFTOVER COMPLETE` (info), `LIFTOVER FAILED` (danger).
- **`pages/hermes/qc/[id].vue`** — New "Liftover Summary" `<Card>` rendered above the QC settings card when a `liftover_jobs` row exists for the file. Shows source → target, totals (in / lifted / unmapped + %), strand-flip count, collapsible per-chromosome `<DataTable>`, chain file + duration, and a "Download unmapped variants" button (presigned S3 GET URL, opens in new tab; disabled when total_unmapped is 0).
- **`pages/hermes/admin/liftover.vue`** *(new)* — Small admin-only page to view/set the portal's `target_genome_build`. Top-level `v-if="isAdmin"` plus `onMounted` redirect for non-admin users (matches the existing inline role-gating pattern in Hermes — no role-aware middleware exists in the codebase).
- **`stores/DatasetStore.js`** — Four new actions: `getLiftoverSummary` (404 → null), `getUnmappedDownloadUrl`, `getPortalConfig`, `updatePortalConfig`. All use the existing `configuredAxios` wrapper.

## Backend dependency

This PR is **paired with `data-registry-api` PR #64**. The new endpoints (`GET /api/hermes/portal-config`, `PUT /api/hermes/portal-config`, `GET /api/hermes/liftover/{file_id}`, `GET .../unmapped-url`) and the modified `POST /api/validate-hermes` (with `genome_build` field) all live in that PR. Merge order: backend first, then this.

## Highlights

- The `n/a` genome build option is intentionally allowed — `should_liftover` returns False for it on the backend, so users who don't know their build flow straight to QC unchanged. The yup validator + Pinia payload + dropdown values all consistently use the literal string `"n/a"` matching `GenomeBuild.na.value` in the API enum.
- `HermesFileStatus.LIFTOVER_COMPLETE` is wired in the status Tag set even though the backend transitions through it synchronously (so users will rarely see it in practice). Keeping the Tag for UI resilience.
- The Liftover Summary card silently does not render when `getLiftoverSummary` returns null (404 case) — most uploads on existing data won't have a liftover_jobs row, so this is the dominant path and shouldn't show an error.

## Deferred

- A role-aware Nuxt middleware for the admin page (current pattern matches the rest of Hermes — inline gate + redirect). Could be a follow-up to harden all Hermes admin surfaces at once.
- Visual charts in the summary card (per the original plan, deferred from v1).
- SGC, CALR, HCM, PEG portals (separate effort once Hermes pattern is proven).

## Test plan

- [x] `npm run build` passes locally (no errors, only pre-existing chunk-size warnings)
- [ ] After backend deploy: upload a real small GWAS file declared as `grch38` while portal target is `hg19`. Verify:
  - Notice appears on step 1 after selecting build
  - Status flow: `SUBMITTED TO LIFTOVER` → `SUBMITTED TO QC` → `READY FOR REVIEW`
  - Summary card renders with correct counts after liftover
  - "Download unmapped variants" button works
  - Build column shows `hg19` after the liftover completes (was `grch38` initially)
- [ ] Upload one declared as `hg19` (matches default portal target). Verify no notice, no liftover row, no liftover card on detail page (regression guard).
- [ ] Visit `/hermes/admin/liftover` as admin: see current target, switch it, verify GET reflects the change. As non-admin: get redirected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)