### PR TITLE
Hermes fixes: auto column-map, alias load bug, upload progress bar

### DIFF
--- a/pages/hermes/new.vue
+++ b/pages/hermes/new.vue
@@ -160,6 +160,13 @@ const missingFileError = ref('');
 const missingMappingError = ref('');
 let fileName = null;
 let previousMapping = {};
+
+// column_map keys that are aliases of canonical dropdown targets (written on
+// save for downstream workers).  They must be stripped before transposing the
+// map into selectedFields, or they can win the transpose and leave the
+// corresponding dropdown blank — e.g. stdErr (6 chars) sorts after se (2
+// chars) in MySQL's JSON key order, so stdErr would overwrite se.
+const COLUMN_MAP_ALIAS_KEYS = ['stdErr', 'reference', 'alt', 'n'];
 const caseAscertainmentOptions = ref([
     { name: "Electronic Health Records", value: "Electronic Health Records" },
     { name: "Research Study", value: "Research Study" }
@@ -282,7 +289,9 @@ async function loadExistingData() {
     };
 
     selectedFields.value = Object.fromEntries(
-        Object.entries(metadata.column_map).filter(([key]) => key !== 'stdErr').map(([key, value]) => [value, key])
+        Object.entries(metadata.column_map)
+            .filter(([key]) => !COLUMN_MAP_ALIAS_KEYS.includes(key))
+            .map(([key, value]) => [value, key])
     );
 
     if (isUpdate.value) {
@@ -371,7 +380,9 @@ watch(selectedMetadataDetails, (newValue) => {
   }
   if(fileInfo.value.columns){
     selectedFields.value = Object.fromEntries(
-        Object.entries(newValue.column_map).map(([key, value]) => [value, key])
+        Object.entries(newValue.column_map)
+            .filter(([key]) => !COLUMN_MAP_ALIAS_KEYS.includes(key))
+            .map(([key, value]) => [value, key])
     );
   }
 });

--- a/pages/hermes/new.vue
+++ b/pages/hermes/new.vue
@@ -468,6 +468,18 @@ async function sampleFile(e) {
         fileInfo.value.columns.forEach((col) => {
             selectedFields.value[col] = null;
         });
+
+        // Auto-suggest mappings from header names → hermes target fields
+        try {
+            const { suggested_map } = await store.suggestHermesColumnMap(fileInfo.value.columns);
+            Object.entries(suggested_map).forEach(([col, target]) => {
+                if (col in selectedFields.value) {
+                    selectedFields.value[col] = target;
+                }
+            });
+        } catch (suggestErr) {
+            console.log('Auto column-map suggestion failed:', suggestErr);
+        }
     } catch (e) {
         console.log(e);
         fileInfo.value = {};

--- a/pages/hermes/new.vue
+++ b/pages/hermes/new.vue
@@ -557,6 +557,8 @@ async function uploadSubmit(){
     try {
       const { presigned_url } = await store.getHermesPresignedUrl(fileName, dataSetName.value)
       await store.uploadToPresignedUrl(presigned_url, file)
+      store.modalMsg = 'Validating file...'
+      store.showProgressBar = false
       const validationRes = await store.validateHermesUpload(
           fileName,
           dataSetName.value,
@@ -576,6 +578,12 @@ async function uploadSubmit(){
       }
     } catch (e) {
       console.log(e)
+    } finally {
+      // Always clear the upload dialog state — otherwise the spinner/progress
+      // bar can persist across a later navigation back to this page.
+      store.processing = false
+      store.showProgressBar = false
+      store.uploadProgress = 0
     }
   }
 }
@@ -592,11 +600,15 @@ async function uploadSubmit(){
         :draggable="false"
         :resizable="false"
     >
+        <div v-if="store.showProgressBar && store.uploadProgress > 0" class="flex flex-column gap-2">
+            <ProgressBar :value="store.uploadProgress" :showValue="true" />
+            <small class="text-center">{{ store.uploadProgress }}% complete</small>
+        </div>
         <ProgressSpinner
-            v-if="store.showProgressBar"
-            :value="store.uploadProgress"
+            v-else
+            style="width: 50px; height: 50px"
             stroke-width="4"
-            animation-duration="0"
+            animation-duration="1s"
         />
     </Dialog>
   <Toast position="top-center" group="default"/>

--- a/stores/DatasetStore.js
+++ b/stores/DatasetStore.js
@@ -373,17 +373,29 @@ export const useDatasetStore = defineStore("DatasetStore", {
             );
         },
         async uploadToPresignedUrl(url, file){
+            // XMLHttpRequest rather than fetch: fetch doesn't expose upload
+            // progress events.  Callers are responsible for resetting
+            // processing/showProgressBar state afterwards.
             const strippedFile = new Blob([file], { type: '' });
-            try {
-                const response = await fetch(url, {
-                    method: 'PUT',
-                    body: strippedFile
+            this.uploadProgress = 0;
+            await new Promise((resolve, reject) => {
+                const xhr = new XMLHttpRequest();
+                xhr.upload.addEventListener('progress', (e) => {
+                    if (e.lengthComputable) {
+                        this.uploadProgress = Math.round((e.loaded * 100) / e.total);
+                    }
                 });
-            } catch (error) {
-                this.processing = false;
-                console.error("File upload failed:", error);
-                throw error;
-            }
+                xhr.addEventListener('load', () => {
+                    if (xhr.status >= 200 && xhr.status < 300) {
+                        resolve();
+                    } else {
+                        reject(new Error(`Upload failed with status ${xhr.status}`));
+                    }
+                });
+                xhr.addEventListener('error', () => reject(new Error('Upload failed')));
+                xhr.open('PUT', url);
+                xhr.send(strippedFile);
+            });
         },
         async getHermesPresignedUrl(fileName, dataset, contentType){
             this.showProgressBar = true;

--- a/stores/DatasetStore.js
+++ b/stores/DatasetStore.js
@@ -344,6 +344,13 @@ export const useDatasetStore = defineStore("DatasetStore", {
             );
             return data.suggested_map;
         },
+        async suggestHermesColumnMap(columns) {
+            const { data } = await configuredAxios.post(
+                "/api/hermes/suggest-column-map",
+                JSON.stringify({ columns }),
+            );
+            return data;
+        },
         async trackBioindex(request) {
             const { data } = await configuredAxios.post(
                 "/api/trackbioindex",


### PR DESCRIPTION
## Summary

Pairs with broadinstitute/data-registry-api#65.

- **Auto-suggest column mapping on file drop**: calls the new `POST /api/hermes/suggest-column-map` after sampling file columns and pre-fills the mapping dropdowns.  Matches hcm/mskkp UX.
- **Fix "SE mapping doesn't get applied" when loading a previous upload's metadata**: `Object.fromEntries` on the transposed `column_map` was letting alias keys (`stdErr`, `reference`, `alt`, `n`) win over their canonical counterparts because of MySQL's length-then-lex JSON key ordering.  Filter all four alias keys on both load paths (edit-existing via `?id=` and the "Select previous metadata" watcher).
- **Real upload progress bar + clean dialog state after redirect**:
  - Switch S3 PUT from `fetch()` to `XMLHttpRequest` so upload progress events drive `uploadProgress`.
  - Swap `<ProgressSpinner>` for `<ProgressBar>` with '%' readout, spinner fallback during the sub-second window before progress events arrive.
  - Wrap the upload branch of `uploadSubmit` in `try/catch/finally` that unconditionally resets `processing`/`showProgressBar`/`uploadProgress` — fixes the bug where the modal stayed up across a subsequent navigation back to `/hermes/new`.
  - Flip `modalMsg` to "Validating file..." between the PUT and the validate-hermes call.

## Test plan

- [x] `npm test` — 2/2 passing locally
- [x] Simulated store states (`processing=true/false`, `uploadProgress=0/42`) via Pinia in a real Nuxt dev session: ProgressBar renders at 42%, spinner fallback works at 0, reset path clears the dialog, round-trip nav doesn't resurrect it.
- [ ] On QA, upload a sizeable file and watch the progress bar advance past 0 → 100.
- [ ] After success redirect, browser-back to `/hermes/new` — no lingering dialog.
- [ ] Re-edit Liftover Real 6 via the pencil icon — SE dropdown shows `se` (not blank).
- [ ] Select a previous upload's metadata on a new upload — SE dropdown populated.
- [ ] Drop a file with common GWAS headers (`CHR, POS, A1, A2, PVAL, N, SE, BETA`) — dropdowns auto-populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)